### PR TITLE
[BUGFIX] Ne pas renvoyer d'erreur si il n'y a pas d'assignement de variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,12 @@
 'use strict';
 
+function report(context, node) {
+  context.report({
+    node: node,
+    messageId: 'chainError',
+  });
+}
+
 module.exports = {
   meta: {
     type: 'problem',
@@ -14,12 +21,21 @@ module.exports = {
   },
   create: function (context) {
     return {
-      'MemberExpression[property.name="withArgs"] > CallExpression > MemberExpression[property.name="stub"][object.name="sinon"]':
+      'VariableDeclarator > CallExpression > MemberExpression[property.name="returns"] > CallExpression > MemberExpression[property.name="withArgs"] > CallExpression > MemberExpression[property.name="stub"][object.name="sinon"]':
         function (node) {
-          context.report({
-            node: node,
-            messageId: 'chainError',
-          });
+          report(context, node);
+        },
+      'VariableDeclarator > CallExpression > MemberExpression[property.name="throws"] > CallExpression > MemberExpression[property.name="withArgs"] > CallExpression > MemberExpression[property.name="stub"][object.name="sinon"]':
+        function (node) {
+          report(context, node);
+        },
+      'VariableDeclarator > CallExpression > MemberExpression[property.name="resolves"] > CallExpression > MemberExpression[property.name="withArgs"] > CallExpression > MemberExpression[property.name="stub"][object.name="sinon"]':
+        function (node) {
+          report(context, node);
+        },
+      'VariableDeclarator > CallExpression > MemberExpression[property.name="rejects"] > CallExpression > MemberExpression[property.name="withArgs"] > CallExpression > MemberExpression[property.name="stub"][object.name="sinon"]':
+        function (node) {
+          report(context, node);
         },
     };
   },

--- a/test.js
+++ b/test.js
@@ -3,7 +3,9 @@
 const rule = require('./index.js'),
   RuleTester = require('eslint').RuleTester;
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+});
 
 ruleTester.run('no-sinon-stub-with-args-oneliner', rule, {
   valid: [
@@ -12,20 +14,49 @@ ruleTester.run('no-sinon-stub-with-args-oneliner', rule, {
       code: 'sinon.stub()',
     },
     {
-      name: 'Two liners',
+      name: 'Sinon import then two liners',
       code: "const stub = sinon.stub(); stub.withArgs('hello').returns('world')",
+    },
+    {
+      name: 'Sinon import then object definition',
+      code: "import sinon from 'sinon'; const stub = { hello: sinon.stub().withArgs('hello').returns('world') }",
+    },
+    {
+      name: 'Stub import then two liners',
+      code: "import { stub } from 'sinon'; const myStub = stub(); myStub.withArgs('hello').returns('world')",
+    },
+
+    // Not handled yet
+    {
+      name: 'Sinon import then onCall one liner',
+      code: "import sinon from 'sinon'; const myStub = sinon.stub().withArgs('hello').onCall(0).returns('world')",
+    },
+    {
+      name: 'Stub import then one liner',
+      code: "import { stub } from 'sinon'; const myStub = stub().withArgs('hello').returns('world')",
     },
   ],
 
   invalid: [
     {
-      name: 'One liner',
-      code: `const stub = sinon.stub().withArgs('hello').returns('world')`,
-      errors: [
-        {
-          messageId: 'chainError',
-        },
-      ],
+      name: 'One liner variable assignment with sinon import and returns',
+      code: `import sinon from 'sinon'; const stub = sinon.stub().withArgs('hello').returns('world')`,
+      errors: [{ messageId: 'chainError' }],
+    },
+    {
+      name: 'One liner variable assignment with sinon import and throws',
+      code: `import sinon from 'sinon'; const stub = sinon.stub().withArgs('hello').throws('world')`,
+      errors: [{ messageId: 'chainError' }],
+    },
+    {
+      name: 'One liner variable assignment with sinon import and resolves',
+      code: `import sinon from 'sinon'; const stub = sinon.stub().withArgs('hello').resolves('world')`,
+      errors: [{ messageId: 'chainError' }],
+    },
+    {
+      name: 'One liner variable assignment with sinon import and rejects',
+      code: `import sinon from 'sinon'; const stub = sinon.stub().withArgs('hello').rejects('world')`,
+      errors: [{ messageId: 'chainError' }],
     },
   ],
 });


### PR DESCRIPTION
## :unicorn: Problème
> Il manque de nuance dans cette règle, il faut distinguer 2 cas : 
>
> **Problématique:** Le cas où on essaie d'assigner à une variable le stub et son comportement : 
> ```
> const monStub = sinon.stub().withArgs(); 
> ```
> Problématique car on pense récupérer un stub mais ce n'est pas le cas
>
> **non problématique** : le cas où on déclare un stub et son comportement : 
> ```
> sinon.stub().withArgs(); 
> ```

Source : https://github.com/1024pix/pix/pull/6331#issuecomment-1590645475

## :robot: Proposition
Détecter si une variable est assignée ou non pour éviter les faux positifs.

Il a fallu préciser quelle méthode était appelée suite au `withArgs` donc la règle ne fonctionne pour l'instant qu'avec `returns`, `throws`, `resolves` et `rejects`.

## :rainbow: Remarques
J'ai ajouté quelques exemples de tests de choses qui ne marchent pas mais qu'il faudrait gérer dans le futur.

## :100: Pour tester
Vérifier que la CI passe, et que les exemples dans la partie "`valid`" font bien casser les tests si on les exécute.